### PR TITLE
Blank subtraction bug fix

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -30,7 +30,7 @@ Unfortunately, the SampleQ system only outputs files using a restrictive file na
 
 This package provides a workaround, allowing the user to compile complex runs using SampleQ via the creation of a 'run sheet', in a fashion that should be familiar to users of other scientific instruments. Even using run setups incorporating multiple blanks, standards and replicates, the combination of SampleQ and **SampleQueue** allows for rapid sample throughput, followed by easy management of the resulting data files. 
 
-##### A quick note on ASCII data types
+#### A quick note on ASCII data types
 
 At present **SampleQueue** supports the Processed Excitation-Emission-Matrix (PEM) and Absorbance (ABS) ASCII .dat file types. See 'Supported file and data types' below. Support for more file types will be added shortly. 
 
@@ -83,6 +83,10 @@ If the user has chosen to export workbook files with their data whilst running t
 
 Depending on user choices during the SampleQ setup process on the Aqualog, a number of different ASCII file types will be exported by the system for each sample during analysis. All ASCII files have the .dat file extension. The current version of **SampleQueue** supports the ABS (absorbance data) and PEM (sample-blank processed XYY) ASCII data types. The others (e.g. % transmission PCT, blank XYY BEM) will be added in a subsequent release. 
 
+## OS Compatibility
+
+The underlying code used for file management (copying, renaming) in **SampleQueue** was written using on a machine running Windows. The package has not been tested on Mac or Linux.
+
 ## Installation
 
 To get access to the functions in **SampleQueue**, simply use the **devtools** package to install the package from github.
@@ -92,6 +96,12 @@ devtools::install_github("MRPHarris/SampleQueue")
 ```
 
 **SampleQueue** has a number of package dependencies. These extend from string handling (e.g. stringr) to a number of packages required for blank subtraction ([eemR](https://cran.r-project.org/web/packages/eemR/index.html), [staRdom](https://github.com/MatthiasPucher/staRdom), and my own package [eemUtils](https://github.com/MRPHarris/eemUtils)). Check the [DESCRIPTION](DESCRIPTION) file for a list of the dependencies. They should all (hopefully) be fetched automatically when you install and load **SampleQueue**.
+
+## Update Notes
+
+22/07/21 | SampleQueue is now fully functional! 
+
+23/07/21 | Fixed a bug wherein attempting blank subtraction on a run that contained no blanks resulted in an error.
 
 ## Planned revisions
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ run setups incorporating multiple blanks, standards and replicates, the
 combination of SampleQ and **SampleQueue** allows for rapid sample
 throughput, followed by easy management of the resulting data files.
 
-##### A quick note on ASCII data types
+#### A quick note on ASCII data types
 
 At present **SampleQueue** supports the Processed
 Excitation-Emission-Matrix (PEM) and Absorbance (ABS) ASCII .dat file
@@ -160,6 +160,12 @@ file extension. The current version of **SampleQueue** supports the ABS
 The others (e.g. % transmission PCT, blank XYY BEM) will be added in a
 subsequent release.
 
+## OS Compatibility
+
+The underlying code used for file management (copying, renaming) in
+**SampleQueue** was written using on a machine running Windows. The
+package has not been tested on Mac or Linux.
+
 ## Installation
 
 To get access to the functions in **SampleQueue**, simply use the
@@ -178,6 +184,13 @@ blank subtraction
 [DESCRIPTION](DESCRIPTION) file for a list of the dependencies. They
 should all (hopefully) be fetched automatically when you install and
 load **SampleQueue**.
+
+## Update Notes
+
+22/07/21 \| SampleQueue is now fully functional!
+
+23/07/21 \| Fixed a bug wherein attempting blank subtraction on a run
+that contained no blanks resulted in an error.
 
 ## Planned revisions
 


### PR DESCRIPTION
Attempting automatic blank subtraction on a run that contained blanks resulted in a non-serious error. Fixed by adding a simple check of the file types in the internal log, and skipping blank subtraction if no milliq blanks are found. Also added a couple of readme updates.