### PR TITLE
PCT ASCII file support

### DIFF
--- a/R/file_type_functions.R
+++ b/R/file_type_functions.R
@@ -51,9 +51,10 @@ extension_strings <- function(type){
 #' @noRd
 #'
 ASCII_strings <- function(){
-  strings_list <- vector(mode = "list", length = 2)
-  names(strings_list) <- c("Absorbance File","Processed EEM")
+  strings_list <- vector(mode = "list", length = 3)
+  names(strings_list) <- c("Absorbance File","Percent Transmission","Processed EEM")
   strings_list[["Absorbance File"]] <- c("Absorbance Data","Absorbance","absorbance data","absorbance","ABS","abs")
+  strings_list[["Percent Transmission"]] <- c("PCT", "PCT data","Transmission data","pct")
   strings_list[["Processed EEM"]] <- c("raw EEM","PEM","pem","Raw EEM data","PEM data","pem data","Excitation Emission Matrix","Excitation Emission Matrice",
                                        "excitation emission matrix","excitation emission matrice","Processed EEM","processed eem")
   strings_list

--- a/R/setup_functions.R
+++ b/R/setup_functions.R
@@ -98,6 +98,7 @@ default_folder_layout <- function(){
   folderx2 <- vector(mode = "list", length = 2)
   folderx3 <- vector(mode = "list", length = 3)
   folderx4 <- vector(mode = "list", length = 4)
+  folderx5 <- vector(mode = "list", length = 5)
   folderx7 <- vector(mode = "list", length = 7)
   # Highest level folders
   SampleQueueFolders <- folderx2
@@ -106,15 +107,15 @@ default_folder_layout <- function(){
   SampleQueueFolders[[2]] <- folderx7
   names(SampleQueueFolders[[2]]) <- c("milliq blanks","sampleq blanks","samples","standards","project files","logs","replicates")
   # Second tier export folders
-  SampleQueueFolders[[2]][["milliq blanks"]] <- folderx3
-  names(SampleQueueFolders[[2]][["milliq blanks"]]) <- c("ABS","PEM","workbooks")
+  SampleQueueFolders[[2]][["milliq blanks"]] <- folderx4
+  names(SampleQueueFolders[[2]][["milliq blanks"]]) <- c("ABS","PCT","PEM","workbooks")
   SampleQueueFolders[[2]][["sampleq blanks"]] <- vector(mode = "list", length = 2)
   names(SampleQueueFolders[[2]][["sampleq blanks"]]) <- c("blank files","workbooks")
-  SampleQueueFolders[[2]][["samples"]] <- folderx4
-  names(SampleQueueFolders[[2]][["samples"]]) <- c("ABS","updated PEM","PEM","workbooks")
-  SampleQueueFolders[[2]][["standards"]] <- folderx4
-  names(SampleQueueFolders[[2]][["standards"]]) <- c("ABS","updated PEM","PEM","workbooks")
-  SampleQueueFolders[[2]][["replicates"]] <- folderx4
-  names(SampleQueueFolders[[2]][["replicates"]]) <- c("ABS","updated PEM","PEM","workbooks")
+  SampleQueueFolders[[2]][["samples"]] <- folderx5
+  names(SampleQueueFolders[[2]][["samples"]]) <- c("ABS","PCT","updated PEM","PEM","workbooks")
+  SampleQueueFolders[[2]][["standards"]] <- folderx5
+  names(SampleQueueFolders[[2]][["standards"]]) <- c("ABS","PCT","updated PEM","PEM","workbooks")
+  SampleQueueFolders[[2]][["replicates"]] <- folderx5
+  names(SampleQueueFolders[[2]][["replicates"]]) <- c("ABS","PCT","updated PEM","PEM","workbooks")
   return(SampleQueueFolders)
 }

--- a/README.Rmd
+++ b/README.Rmd
@@ -32,7 +32,7 @@ This package provides a workaround, allowing the user to compile complex runs us
 
 #### A quick note on ASCII data types
 
-At present **SampleQueue** supports the Processed Excitation-Emission-Matrix (PEM) and Absorbance (ABS) ASCII .dat file types. See 'Supported file and data types' below. Support for more file types will be added shortly. 
+At present **SampleQueue** supports the Processed Excitation-Emission-Matrix (PEM), Absorbance (ABS), and Percent Transmission (PCT) ASCII .dat file types. See 'Supported file and data types' below. 
 
 ## Using the SampleQueue package
 
@@ -81,7 +81,7 @@ If the user has chosen to export workbook files with their data whilst running t
 
 ### ASCII .dat files
 
-Depending on user choices during the SampleQ setup process on the Aqualog, a number of different ASCII file types will be exported by the system for each sample during analysis. All ASCII files have the .dat file extension. The current version of **SampleQueue** supports the ABS (absorbance data) and PEM (sample-blank processed XYY) ASCII data types. The others (e.g. % transmission PCT, blank XYY BEM) will be added in a subsequent release. 
+Depending on user choices during the SampleQ setup process on the Aqualog, a number of different ASCII file types will be exported by the system for each sample during analysis. All ASCII files have the .dat file extension. The current version of **SampleQueue** supports the ABS (absorbance data), PEM (sample-blank processed XYY) and PCT (percent transmission) ASCII data types. The others will be added sporadically as needed. 
 
 ## OS Compatibility
 
@@ -103,7 +103,9 @@ devtools::install_github("MRPHarris/SampleQueue")
 
 23/07/21 | Fixed a bug wherein attempting blank subtraction on a run that contained no blanks resulted in an error.
 
-06/09/21 | Targeted blank subtraction function replaced with a generalised 'post processing' function. The user can now optionally perform blank subtraction as before, along with dilution using a new column in the run sheet (Dilution_Factor). Various parts in the `process_sample_queue()` function have also been made more verbose. This adds clutter to the console, but aids in error checking - it should be pretty clear which part in the process caused a failure, if one occurs. 
+06/09/21 | Dilution support added. Targeted blank subtraction replaced with a generalised 'post processing' function. The user can now optionally perform blank subtraction as before, along with dilution using a new column in the run sheet (Dilution_Factor). Various parts in the `process_sample_queue()` function have also been made more verbose. This adds clutter to the console, but aids in error checking - it should be pretty clear which part in the process caused a failure, if one occurs. 
+
+07/09/21 | Percent transmission (PCT) .dat ASCII file support added. PCT .dat files now export in the same fashion as ABS files, to their own folder in the file type export sub-directory. 
 
 ## Planned revisions
 

--- a/README.md
+++ b/README.md
@@ -38,9 +38,9 @@ package also has support for automatic multi-blank subtraction.
 #### A quick note on ASCII data types
 
 At present **SampleQueue** supports the Processed
-Excitation-Emission-Matrix (PEM) and Absorbance (ABS) ASCII .dat file
-types. See ‘Supported file and data types’ below. Support for more file
-types will be added shortly.
+Excitation-Emission-Matrix (PEM), Absorbance (ABS), and Percent
+Transmission (PCT) ASCII .dat file types. See ‘Supported file and data
+types’ below.
 
 ## Using the SampleQueue package
 
@@ -159,9 +159,9 @@ Depending on user choices during the SampleQ setup process on the
 Aqualog, a number of different ASCII file types will be exported by the
 system for each sample during analysis. All ASCII files have the .dat
 file extension. The current version of **SampleQueue** supports the ABS
-(absorbance data) and PEM (sample-blank processed XYY) ASCII data types.
-The others (e.g. % transmission PCT, blank XYY BEM) will be added in a
-subsequent release.
+(absorbance data), PEM (sample-blank processed XYY) and PCT (percent
+transmission) ASCII data types. The others will be added sporadically as
+needed.
 
 ## OS Compatibility
 
@@ -195,13 +195,18 @@ load **SampleQueue**.
 23/07/21 \| Fixed a bug wherein attempting blank subtraction on a run
 that contained no blanks resulted in an error.
 
-06/09/21 \| Targeted blank subtraction function replaced with a
-generalised ‘post processing’ function. The user can now optionally
-perform blank subtraction as before, along with dilution using a new
-column in the run sheet (Dilution\_Factor). Various parts in the
-`process_sample_queue()` function have also been made more verbose. This
-adds clutter to the console, but aids in error checking - it should be
-pretty clear which part in the process caused a failure, if one occurs.
+06/09/21 \| Dilution support added. Targeted blank subtraction replaced
+with a generalised ‘post processing’ function. The user can now
+optionally perform blank subtraction as before, along with dilution
+using a new column in the run sheet (Dilution\_Factor). Various parts in
+the `process_sample_queue()` function have also been made more verbose.
+This adds clutter to the console, but aids in error checking - it should
+be pretty clear which part in the process caused a failure, if one
+occurs.
+
+07/09/21 \| Percent transmission (PCT) .dat ASCII file support added.
+PCT .dat files now export in the same fashion as ABS files, to their own
+folder in the file type export sub-directory.
 
 ## Planned revisions
 


### PR DESCRIPTION
Support added for PCT (pwecent transmission) .dat ASCII file types. PCT data now handled in a similar fashion to ABS data - a dedicated folder now exists in the folder framework where applicable.