### PR TITLE
added run-sheet type 'other' for run mishap workarounds

### DIFF
--- a/R/file_type_functions.R
+++ b/R/file_type_functions.R
@@ -8,14 +8,15 @@
 #'
 type_strings <- function(){
   # There are broadly 5 types.
-  type_string_list <- vector(mode = "list", length = 5)
-  names(type_string_list) <- c("Sample Queue Blank", "MilliQ Water Blank", "Sample","Standard","Replicate")
+  type_string_list <- vector(mode = "list", length = 7)
+  names(type_string_list) <- c("Sample Queue Blank", "MilliQ Water Blank", "Procedural Blank", "Sample","Standard","Replicate","Other")
   type_string_list[["Sample Queue Blank"]] <- c("sqblank","sq","sampleqblank","sampleq blank","SampleQ","SampleQBlank","SQ","SampleQ Blank", "samplpe queue blank","Sample Queue Blank")
   type_string_list[["MilliQ Water Blank"]] <- c("mqblank","milliq","milliqblank","milliq blank","MilliQ","MilliQBlank","MQ","mq","MilliQ Blank","milli-q blank","Milli-Q Blank","milli-q water blank","Milli-Q Water Blank")
   type_string_list[["Procedural Blank"]] <- c("pblank","procblank","proceduralblank","procedural blank", "ProceduralBlank","Procedural Blank","pb","PB")
   type_string_list[["Sample"]] <- c("Sample","sample")
   type_string_list[["Standard"]] <- c("STD","std","Standard","standard")
   type_string_list[["Replicate"]] <- c("Replicate","replicate","rep","Rep","Repeat","repeat","Rpt","rpt")
+  type_string_list[["Other"]] <- c("Other","other","misc","Misc","miscellaneous","Miscellaneous")
   type_string_list
 }
 
@@ -35,7 +36,7 @@ extension_strings <- function(type){
     strings_list[["Blank File"]] <- c("blank files","blank file","Blank Files","Blank File")
     strings_list[["Workbook File"]] <- c("workbook","workbooks","Workbook","Workbooks","Workbook File","workbook file","Workbook Files","workbook files")
     strings_list
-  } else if(type == "Sample" || type == "MilliQ Water Blank" || type == "Replicate" || type == "Standard" || type == "Procedural Blank"){
+  } else if(type == "Sample" || type == "MilliQ Water Blank" || type == "Replicate" || type == "Standard" || type == "Procedural Blank" || type = "Other"){
     strings_list <- vector(mode = "list", length = 2)
     names(strings_list) <- c("Workbook File","ASCII Data File")
     strings_list[["Workbook File"]] <- c("workbook","workbooks","Workbook","Workbooks","Workbook File","workbook file","Workbook Files","workbook files")

--- a/R/process_sample_queue.R
+++ b/R/process_sample_queue.R
@@ -103,7 +103,7 @@ process_sample_queue <- function(folder,
       } else if(isTRUE(dry_run)){
         message("Dry run. Files related to run-sheet row ",r," (",type_it,")"," were added to the file log.")
       }
-    } else if(type_it == "Sample" || type_it == "MilliQ Water Blank" || type_it == "Replicate" || type_it == "Standard" || type_it == "Procedural Blank"){
+    } else if(type_it == "Sample" || type_it == "MilliQ Water Blank" || type_it == "Replicate" || type_it == "Standard" || type_it == "Procedural Blank" || type_it == "Other"){
       ## "NORMAL" FILES
       # This is the type folder where the files will end up.
       row_type_folder <- get_type_folder(run_sheet_row = row_it,

--- a/R/setup_functions.R
+++ b/R/setup_functions.R
@@ -119,5 +119,7 @@ default_folder_layout <- function(){
   names(SampleQueueFolders[[2]][["replicates"]]) <- c("ABS","PCT","updated PEM","PEM","workbooks")
   SampleQueueFolders[[2]][["procedural blanks"]] <- folderx5
   names(SampleQueueFolders[[2]][["procedural blanks"]]) <- c("ABS","PCT","updated PEM","PEM","workbooks")
+  SampleQueueFolders[[2]][["other"]] <- folderx4
+  names(SampleQueueFolders[[2]][["other"]]) <- c("ABS","PCT","PEM","workbooks")
   return(SampleQueueFolders)
 }

--- a/README.Rmd
+++ b/README.Rmd
@@ -140,6 +140,8 @@ devtools::install_github("MRPHarris/SampleQueue")
 
 18/10/21 | Added support for a second 'layer' of optional blank subtraction, in the form of a 'pblank' run sheet type. This is intended for procedural blanks - blanks which aim to capture one or more treatment steps prior to/upstream of laboratory handling. This might include blanks of storage containers or sampling equipment. Procedural blanks are first subject to dilution handling and milli-q blank subtraction, where appropriate. They are then averaged (if more than one is present in a run) and subtracted from samples and replicates in the run. Note that pblanks are *not* subtracted from standards, as those are assumed to not be subject to the upstream protocol targeted with the pblank/s.
 
+03/11/21 | Added an additional run-sheet row type, 'other'. Rows in the run sheet listed as type 'other' will have their files sorted and sent to the 'other' folder within the export directory without any post-processing. This is intended for use with samples that didn't run properly - either due to premature ending of a run, or user error (e.g. mismatch of samples, accidental repeats, etc.). 
+
 ## Planned revisions
 
 - update error checking to provide more useful information in the event of (1) file copy failure, and (2) project file transfers. Some common errors (such as incompatible date usage, run sheet name/file mismatches) could probably be diagnosed automatically fairly easily. 

--- a/README.md
+++ b/README.md
@@ -264,6 +264,13 @@ run. Note that pblanks are *not* subtracted from standards, as those are
 assumed to not be subject to the upstream protocol targeted with the
 pblank/s.
 
+03/11/21 \| Added an additional run-sheet row type, ‘other’. Rows in the
+run sheet listed as type ‘other’ will have their files sorted and sent
+to the ‘other’ folder within the export directory without any
+post-processing. This is intended for use with samples that didn’t run
+properly - either due to premature ending of a run, or user error
+(e.g. mismatch of samples, accidental repeats, etc.).
+
 ## Planned revisions
 
 -   update error checking to provide more useful information in the


### PR DESCRIPTION
Added an extra, simple run-sheet row type, named 'other'. Files related to a row in the run sheet designated as type 'other' will be sorted (as per usual ASCII data and worksheet handling rules) and sent to the 'other' folder within the export directory, without post-processing. It is intended as a simple error workaround - got a sample that didn't run properly, or that you mishandled? Just send it to the 'other' folder and deal with it later, rather than having to separate it from the other files in its usual type folder. 